### PR TITLE
FE : SelectBox 기능수정 및 디자인수정 #53

### DIFF
--- a/components/SelectBox/index.tsx
+++ b/components/SelectBox/index.tsx
@@ -7,16 +7,20 @@ import {
 } from "./styled";
 import useOutsideClick from "../../hooks/useOutsideClick";
 
-interface SelectBoxProps {
-  options: Array<string | number>;
-  setValue: React.Dispatch<React.SetStateAction<any>>;
+interface OptionsType {
+  name: string;
   value: string | number;
+}
+interface SelectBoxProps {
+  options: OptionsType[];
+  setValue: React.Dispatch<React.SetStateAction<any>>;
   title?: string | number;
   size?: "small" | "medium" | "large";
 }
 
-function SelectBox({ options, setValue, value, title, size }: SelectBoxProps) {
+function SelectBox({ options, setValue, title, size }: SelectBoxProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const [name, setName] = useState(title);
   const selectRef = useRef<HTMLDivElement>(null);
   useOutsideClick(selectRef, () => {
     setIsVisible(false);
@@ -24,25 +28,28 @@ function SelectBox({ options, setValue, value, title, size }: SelectBoxProps) {
   const handleSelectVisible = () => {
     setIsVisible(!isVisible);
   };
-  const handleOnChangeSelectValue = (e: React.MouseEvent<HTMLLIElement>) => {
-    const { innerText } = e.target as HTMLLIElement;
-    for (let i = 0; i < options.length; i++) {
-      if (typeof options[i] === "number") {
-        setValue(Number(innerText));
-      } else {
-        setValue(innerText);
-      }
-    }
+  const handleOnChangeSelectValue = <T extends string | number>(
+    value: T,
+    name: T,
+  ): void => {
+    setValue(value);
+    setName(name);
   };
+
   return (
     <SelectWrapper onClick={handleSelectVisible} ref={selectRef} size={size}>
-      <SelectValue>{value ? value : title}</SelectValue>
+      <SelectValue>{name ? name : title}</SelectValue>
       <SelectOptionWrapper visible={isVisible}>
         {options &&
-          options.map((option: string | number) => {
+          options.map((option) => {
             return (
-              <SelectOption key={option} onClick={handleOnChangeSelectValue}>
-                {option}
+              <SelectOption
+                key={option.name}
+                onClick={() =>
+                  handleOnChangeSelectValue(option.value, option.name)
+                }
+              >
+                {option.name}
               </SelectOption>
             );
           })}
@@ -52,8 +59,6 @@ function SelectBox({ options, setValue, value, title, size }: SelectBoxProps) {
 }
 export default React.memo(SelectBox);
 
-// export default SelectBox;
 //SelectBox 컴포넌트의 사용법은 부모컴포넌트로부터 4개의 props 를 받아야합니다.
-//options(셀렉트박스안에 들어갈 여러개의 값들의 객체or배열),value(부모컴포넌트의state),setValue(부모컴포넌트의 setState),title(첫 렌더링시 어떤 셀렉트박스인지 구분하기위한 props)
+//options 객체기 필요합니다. 객체의 양식은 {name"abcd",value:"abcd"}이며  name은 화면에 보여질 값 value 는 백엔드에 보낼 값입니다.
 //이 컴포넌트를 사용하는 페이지에서 useState를 사용하여 값을 관리해주시면 됩니다.
-//pages/userinfo/position.tsx 에서 사용법을 확인할 수 있습니다.

--- a/components/SelectBox/index.tsx
+++ b/components/SelectBox/index.tsx
@@ -14,7 +14,7 @@ interface OptionsType {
 interface SelectBoxProps {
   options: OptionsType[];
   setValue: React.Dispatch<React.SetStateAction<any>>;
-  title?: string | number;
+  title: string | number;
   size?: "small" | "medium" | "large";
 }
 

--- a/components/SelectBox/styled.ts
+++ b/components/SelectBox/styled.ts
@@ -37,7 +37,7 @@ export const SelectWrapper = styled.div`
 export const SelectOptionWrapper = styled.ul<SelectOptionType>`
   visibility: ${(p) => (p.visible ? "visible" : "hidden")};
   opacity: ${(p) => (p.visible ? "1" : "0")};
-  transform: ${(p) => (p.visible ? "translateY(0%)" : "translateY(-25%)")};
+  transform: ${(p) => (p.visible ? "translateY(0%)" : "translateY(-20%)")};
   transition: 0.2s ease-in-out;
   margin: 0;
   padding: 0;
@@ -49,15 +49,17 @@ export const SelectOptionWrapper = styled.ul<SelectOptionType>`
   width: 100%;
   z-index: 10;
   margin-top: 0.5rem;
+  max-height: 300px;
+  overflow: auto;
 `;
 export const SelectOption = styled.li`
   border-radius: 5px;
+  text-align: center;
+  padding: 20px 20px;
   &:hover {
     background-color: #eaecf0;
     color: black;
   }
-  text-align: center;
-  padding: 10px 20px;
 `;
 export const SelectValue = styled.div`
   box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px,

--- a/components/pages/mypageEdit/Info/index.tsx
+++ b/components/pages/mypageEdit/Info/index.tsx
@@ -17,14 +17,20 @@ interface InfoEditProps {
   blog: string | undefined;
   portfolio: string | undefined;
 }
-const SELECT_CAREER = ["0", "1~3", "4~6", "7년 이상 "];
 const SELECT_POSITIONS = [
-  "프론트엔드",
-  "백엔드",
-  "디자이너",
-  "데브옵스",
-  "기획자",
-  "마케터",
+  { name: "프론트엔드", value: "frontend" },
+  { name: "백엔드", value: "backend" },
+  { name: "디자이너", value: "designer" },
+  { name: "데브옵스", value: "devops" },
+  { name: "기획자", value: "marketer" },
+  { name: "마케터", value: "pm" },
+];
+const SELECT_CAREER = [
+  { name: "취업준비생", value: "empty" },
+  { name: "신입(0년차)", value: "new" },
+  { name: "주니어(1~3년차)", value: "junior" },
+  { name: "미들(4~6년차)", value: "middle" },
+  { name: "시니어(7년이상)", value: "sinior" },
 ];
 export default function InfoEdit({
   career,
@@ -43,18 +49,12 @@ export default function InfoEdit({
         <SelectBox
           options={SELECT_POSITIONS}
           setValue={setPosition}
-          value={position}
           title="포지션"
         />
       </InfoWrapper>
       <InfoWrapper>
         <InfoTitle>*경력</InfoTitle>
-        <SelectBox
-          options={SELECT_CAREER}
-          setValue={setCareer}
-          value={career}
-          title="경력"
-        />
+        <SelectBox options={SELECT_CAREER} setValue={setCareer} title="경력" />
       </InfoWrapper>
       <InfoWrapper>
         <InfoTitle>깃허브</InfoTitle>

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -10,7 +10,13 @@ import { useAppDispatch } from "../../store/hooks";
 import { openModal } from "../../store/modalSlice";
 import { media } from "@/styles/mediatest";
 import axios from "axios";
-const FILTER_OPTIONS = ["조회순", "추천순", "댓글순"];
+const FILTER_OPTIONS = [
+  { name: "최신순", value: "latest" },
+  { name: "조회순", value: "view" },
+  { name: "추천순", value: "like" },
+  { name: "댓글순", value: "comment" },
+];
+
 interface ProjectList {
   id: number;
   content: string;
@@ -23,7 +29,7 @@ interface InfiniteProjectType {
   projects: ProjectList[];
 }
 export default function ProjectPage() {
-  const [filter, setFilter] = useState("조회순");
+  const [filter, setFilter] = useState("latest");
   const [keyword, setKeyword] = useState("");
   //threshold : inview가 보여지는 정도를 0~1까지 조절하여 트리거시점을 조절할수있다 0이면 보이자마자 트리거 1이면 전체가 다보여야 트리거
   const { ref, inView } = useInView({ threshold: 0 });
@@ -55,7 +61,7 @@ export default function ProjectPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inView, hasNextPage]);
   const dispatch = useAppDispatch();
-  console.log(data);
+  console.log(filter);
   return (
     <Wrapper>
       <button
@@ -71,9 +77,8 @@ export default function ProjectPage() {
       <FilterSection>
         <SelectBox
           options={FILTER_OPTIONS}
-          value={filter}
           setValue={setFilter}
-          size="large"
+          title="최신순"
         />
         <Search setKeyword={setKeyword} />
       </FilterSection>

--- a/pages/userinfo/position.tsx
+++ b/pages/userinfo/position.tsx
@@ -14,23 +14,19 @@ import {
 import Button from "../../components/Button";
 
 const SELECT_POSITIONS = [
-  "프론트엔드",
-  "백엔드",
-  "디자이너",
-  "데브옵스",
-  "기획자",
-  "마케터",
+  { name: "프론트엔드", value: "frontend" },
+  { name: "백엔드", value: "backend" },
+  { name: "디자이너", value: "designer" },
+  { name: "데브옵스", value: "devops" },
+  { name: "기획자", value: "marketer" },
+  { name: "마케터", value: "pm" },
 ];
 const SELECT_CAREER = [
-  // "취업준비생",
-  // "신입(0년차)",
-  // "주니어(1~3년차)",
-  // "미들(4~6년차)",
-  // "시니어(7년이상)",
-  "0",
-  "1~3",
-  "4~6",
-  "7년 이상 ",
+  { name: "취업준비생", value: "empty" },
+  { name: "신입(0년차)", value: "new" },
+  { name: "주니어(1~3년차)", value: "junior" },
+  { name: "미들(4~6년차)", value: "middle" },
+  { name: "시니어(7년이상)", value: "sinior" },
 ];
 interface FormData {
   github: string;
@@ -61,13 +57,11 @@ export default function Position() {
           <SelectBox
             options={SELECT_POSITIONS}
             setValue={setPosition}
-            value={position}
             title="포지션"
           />
           <SelectBox
             options={SELECT_CAREER}
             setValue={setCareer}
-            value={career}
             title="경력"
           />
         </SelectSection>


### PR DESCRIPTION
기능수정 : 화면에서 보여지는 값과 백엔드에 보내질 값을 분리하였습니다.
디자인수정 : 랜더링하고싶은 목록이 많을경우 overflow가 됩니다.

**사용방법**
![image](https://github.com/Side-Effect-Team/side-effect-frontend/assets/96623949/bd78c805-1d98-474c-b886-953124ccfdf8)
랜더링하고싶은 데이터의 양식입니다 name 은 화면에 보여지는값 value 는 백엔드에 보내질값입니다. 양식은 맞춰서 보내주셔야합니다.

![image](https://github.com/Side-Effect-Team/side-effect-frontend/assets/96623949/94bb02c9-c92a-4f15-9dad-30cbede5828f)
해당페이지에서 사용하기위해 상태로 관리합니다. 초기에 필터하고싶은값이 있다면 value에맞게 초기값으로 넣어주시면됩니다.
상태변경함수는 prop으로 SelectBox에 전달합니다.

![image](https://github.com/Side-Effect-Team/side-effect-frontend/assets/96623949/460ce546-1a3d-4188-8a92-8868522aac9b)
opions,setValue,title 은 필수로 넘겨주셔야합니다 위에서 설명안드린 title은 화면에 보여질 초기값이라고 생각하시면 됩니다. 
