### PR TITLE
FE: PageHead 컴포넌트 생성 및 모바일 메뉴 헤더 수정

### DIFF
--- a/components/Banner/styled.ts
+++ b/components/Banner/styled.ts
@@ -33,7 +33,7 @@ export const Contents = styled.div`
   gap: 1rem;
   align-items: center;
   justify-content: center;
-  z-index: 5;
+  z-index: 3;
 
   h2 {
     font-size: 2.5rem;

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -33,7 +33,7 @@ export default function Layout({ children }: PropType) {
   const router = useRouter();
   const currentPage = router.route;
 
-  const handleMobileMenu = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleMobileMenu = () => {
     setMobileMenuOpen((prev) => !prev);
   };
 
@@ -61,10 +61,6 @@ export default function Layout({ children }: PropType) {
       </>
     );
   }
-
-  useEffect(() => {
-    console.log(mobileMenuOpen);
-  }, [mobileMenuOpen]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -24,6 +24,10 @@ const MOBILE_BOARD_LIST = [
   },
 ];
 
+interface MobileMenuProps {
+  hide: boolean;
+}
+
 export default function Layout({ children }: PropType) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState<boolean>(false);
   const router = useRouter();
@@ -58,21 +62,25 @@ export default function Layout({ children }: PropType) {
     );
   }
 
+  useEffect(() => {
+    console.log(mobileMenuOpen);
+  }, [mobileMenuOpen]);
+
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyles />
       <Header handleMobileMenu={handleMobileMenu} />
       <Toast />
-      {mobileMenuOpen && <MobileMenu />}
+      <MobileMenu hide={!mobileMenuOpen} />
       <Wrapper mobileMenuOpen={mobileMenuOpen}>{children}</Wrapper>
       <Footer />
     </ThemeProvider>
   );
 }
 
-function MobileMenu() {
+function MobileMenu({ hide }: MobileMenuProps) {
   return (
-    <MobileNavBar>
+    <MobileNavBar hide={hide}>
       {MOBILE_BOARD_LIST.map((board) => (
         <MobileMenuItem key={board.ID}>
           <Link href={board.LINK}>{board.TITLE}</Link>

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -11,6 +11,7 @@ import Footer from "../Footer";
 import Toast from "../Toast";
 import { BOARD_LIST } from "../../enum";
 import ScrollToTop from "../ScrollToTop";
+import PageHead from "components/PageHead";
 
 interface PropType {
   children: React.ReactNode;
@@ -66,6 +67,7 @@ export default function Layout({ children }: PropType) {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyles />
+      <PageHead pageTitle="사이드 이펙트 | 빠르게 프로젝트를 시작하세요" />
       <Header handleMobileMenu={handleMobileMenu} />
       <ScrollToTop />
       <Toast />

--- a/components/Layout/styled.ts
+++ b/components/Layout/styled.ts
@@ -1,25 +1,32 @@
 import styled, { css } from "styled-components";
-import { mediaQuery } from "../../styles/Media";
+import { mediaQuery } from "@/styles/Media";
 
 interface WrapperProps {
   mobileMenuOpen: boolean;
 }
 
+interface MobileNavBarProps {
+  hide: boolean;
+}
+
 export const Wrapper = styled.div<WrapperProps>`
   margin-top: ${(p) => p.theme.height.header};
-
-  ${(p) =>
-    p.mobileMenuOpen &&
-    css`
-      ${mediaQuery("mobile")`
-        margin-top: 0;
-      `};
-    `}
 `;
 
-export const MobileNavBar = styled.nav`
+export const MobileNavBar = styled.nav<MobileNavBarProps>`
+  position: fixed;
+  z-index: 5;
+  transition: all ease-out 0.75s;
+  ${(p) =>
+    p.hide
+      ? css`
+          top: -50px;
+        `
+      : css`
+          top: 75px;
+        `}
+
   ${mediaQuery("mobile")`
-    margin-top: 75px;
     background: #eee;
     width: 100%;
   `}
@@ -31,6 +38,8 @@ export const MobileMenuItem = styled.div`
   justify-content: center;
   align-items: center;
   border-bottom: 1px solid black;
+  font-size: 1.5rem;
+  font-weight: 600;
 
   &:first-child {
     border-top: 1px solid black;

--- a/components/MobileMenuButton/styled.ts
+++ b/components/MobileMenuButton/styled.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { mediaQuery } from "../../styles/Media";
+import { mediaQuery } from "@/styles/Media";
 
 export const Wrapper = styled.div`
   ${mediaQuery("mobile")`

--- a/components/PageHead/index.tsx
+++ b/components/PageHead/index.tsx
@@ -1,0 +1,13 @@
+import Head from "next/head";
+
+interface PageHeadProps {
+  pageTitle: string;
+}
+
+export default function PageHead({ pageTitle }: PageHeadProps) {
+  return (
+    <Head>
+      <title>{pageTitle}</title>
+    </Head>
+  );
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -38,7 +38,12 @@ class MyDocument extends Document {
   render() {
     return (
       <Html lang="ko">
-        <Head />
+        <Head>
+          <meta
+            httpEquiv="Content-Security-Policy"
+            content="upgrade-insecure-requests"
+          />
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -40,6 +40,10 @@ class MyDocument extends Document {
       <Html lang="ko">
         <Head>
           <meta
+            name="viewport"
+            content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+          />
+          <meta
             httpEquiv="Content-Security-Policy"
             content="upgrade-insecure-requests"
           />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -43,10 +43,6 @@ class MyDocument extends Document {
             name="viewport"
             content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
           />
-          <meta
-            httpEquiv="Content-Security-Policy"
-            content="upgrade-insecure-requests"
-          />
         </Head>
         <body>
           <Main />

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -11,6 +11,7 @@ import {
   SectionWrapper,
   Wrapper,
 } from "@/components/pages/mypage/styled";
+import PageHead from "@/components/PageHead";
 
 export interface DataProps {
   avatarSrc?: string;
@@ -55,6 +56,7 @@ export default function MyPage() {
 
   return (
     <Wrapper>
+      <PageHead pageTitle="마이페이지 | 사이드 이펙트" />
       <Introduction
         avatarSrc={data.avatarSrc}
         nickname={data.nickname}

--- a/pages/post/project.tsx
+++ b/pages/post/project.tsx
@@ -19,6 +19,7 @@ import { useForm } from "@/hooks/useForm";
 import { useInputImage } from "@/hooks/useInputImage";
 import ProjectUrlBox from "@/postComps/ProjectUrlBox";
 import { DEFAULT_PROJECT_CARD_IMAGE } from "../../enum";
+import PageHead from "@/components/PageHead";
 
 export const POST_FORM = {
   projectName: "",
@@ -80,6 +81,7 @@ export default function PostProjectPage() {
 
   return (
     <Wrapper>
+      <PageHead pageTitle="프로젝트 자랑 글쓰기 | 사이드 이펙트" />
       <Contents>
         <PostTitleStyled>프로젝트 자랑하기</PostTitleStyled>
         <form onSubmit={handleSubmit}>

--- a/pages/post/recruit.tsx
+++ b/pages/post/recruit.tsx
@@ -23,6 +23,7 @@ import { useForm } from "@/hooks/useForm";
 import PositionBox from "@/postComps/PositionBox";
 import { useInputImage } from "@/hooks/useInputImage";
 import { DEFAULT_RECRUIT_CARD_IMAGE } from "../../enum";
+import PageHead from "@/components/PageHead";
 
 export const POSITIONS = [
   {
@@ -119,6 +120,7 @@ export default function PostRecruitPage() {
 
   return (
     <Wrapper>
+      <PageHead pageTitle="팀원 모집 글쓰기 | 사이드 이펙트" />
       <Contents>
         <PostTitleStyled>팀원 모집하기</PostTitleStyled>
         <form onSubmit={handleSubmit}>

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -10,6 +10,7 @@ import { useAppDispatch } from "../../store/hooks";
 import { openModal } from "../../store/modalSlice";
 import { media } from "@/styles/mediatest";
 import axios from "axios";
+import PageHead from "@/components/PageHead";
 const FILTER_OPTIONS = [
   { name: "최신순", value: "latest" },
   { name: "조회순", value: "view" },
@@ -64,6 +65,7 @@ export default function ProjectPage() {
   console.log(filter);
   return (
     <Wrapper>
+      <PageHead pageTitle="프로젝트 자랑 | 사이드 이펙트" />
       <button
         onClick={() => dispatch(openModal({ modalType: "ManageTeamModal" }))}
       >

--- a/pages/recruits/index.tsx
+++ b/pages/recruits/index.tsx
@@ -6,6 +6,7 @@ import { breakPoints, mediaQuery } from "@/styles/Media";
 import Banner from "@/components/Banner";
 import BoardCard from "@/components/BoardCard";
 import { BANNER_CONTENTS } from "../../enum";
+import PageHead from "@/components/PageHead";
 
 interface RecruitType {
   id: number;
@@ -44,6 +45,7 @@ export default function RecruitsPage() {
 
   return (
     <Wrapper>
+      <PageHead pageTitle="팀원 모집 | 사이드 이펙트" />
       <Banner
         title={BANNER_CONTENTS.TITLE}
         subTitle={BANNER_CONTENTS.SUB_TITLE}


### PR DESCRIPTION
PageHead 컴포넌트 생성
- 각 페이지의 제목을 담기 위한 PageHead 컴포넌트를 추가했습니다
- pageTitle props로 원하는 page title을 설정할 수 있습니다
- 몇 개의 페이지에 기본 컴포넌트를 만들어 놓았습니다
- PageHead 컴포넌트가 없는 페이지는 기본으로 "사이드 이펙트" 라는 page title을 갖게 됩니다 (Layout 컴포넌트 내 기본 배치)
- <title /> 이외에 다른 meta tag를 추가할 수도 있습니다

모바일 메뉴 헤더 수정
- 페이지 스크롤이 중간으로 내린 상황에서 모바일 메뉴를 펼칠 수 있게 수정하였습니다
- 스크롤 애니메이션을 추가했습니다