### PR TITLE
FE: 프로젝트 자랑 게시글 편집 및 기타 fix

### DIFF
--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -28,6 +28,7 @@ const MOBILE_BOARD_LIST = [
 
 interface MobileMenuProps {
   hide: boolean;
+  handleClick: () => void;
 }
 
 export default function Layout({ children }: PropType) {
@@ -77,26 +78,26 @@ export default function Layout({ children }: PropType) {
       <Header handleMobileMenu={handleMobileMenu} />
       <ScrollToTop />
       <Toast />
-      <MobileMenu hide={!mobileMenuOpen} />
+      <MobileMenu hide={!mobileMenuOpen} handleClick={handleMobileMenu} />
       <Wrapper mobileMenuOpen={mobileMenuOpen}>{children}</Wrapper>
       <Footer />
     </ThemeProvider>
   );
 }
 
-function MobileMenu({ hide }: MobileMenuProps) {
+function MobileMenu({ hide, handleClick }: MobileMenuProps) {
   return (
     <MobileNavBar hide={hide}>
       {MOBILE_BOARD_LIST.map((board) => {
         if (board.TITLE === "로그인") {
           return (
-            <MobileMenuItem key={board.ID} onClick={() => console.log("클릭")}>
+            <MobileMenuItem key={board.ID} onClick={handleClick}>
               <Link href={board.LINK}>{board.TITLE}</Link>
             </MobileMenuItem>
           );
         }
         return (
-          <MobileMenuItem key={board.ID}>
+          <MobileMenuItem key={board.ID} onClick={handleClick}>
             <Link href={board.LINK}>{board.TITLE}</Link>
           </MobileMenuItem>
         );

--- a/components/Layout/styled.ts
+++ b/components/Layout/styled.ts
@@ -16,7 +16,7 @@ export const Wrapper = styled.div<WrapperProps>`
 export const MobileNavBar = styled.nav<MobileNavBarProps>`
   position: fixed;
   z-index: 5;
-  transition: all ease-out 0.75s;
+  transition: all ease-out 0.5s;
   ${(p) =>
     p.hide
       ? css`

--- a/components/pages/detailPage/ContentDetail/index.tsx
+++ b/components/pages/detailPage/ContentDetail/index.tsx
@@ -1,16 +1,19 @@
+import { Column } from "../PostData/styled";
 import {
   Wrapper,
   StyledHeader,
   Keyword,
   Description,
   TagContainer,
+  ProjectTitle,
+  ProjectTitleBox,
 } from "@/detailComps/ContentDetail/styled";
 import { TagWrapper } from "@/postComps/TagBox/styled";
 
 interface ContentDetailProps {
   projectName: string;
   content: string;
-  tags: TagType[];
+  tags?: TagType[];
 }
 
 export default function ContentDetail({
@@ -20,17 +23,29 @@ export default function ContentDetail({
 }: ContentDetailProps) {
   return (
     <Wrapper>
-      <StyledHeader>사용 기술</StyledHeader>
-      <TagContainer>
-        <div>
-          {tags.map((tag) => (
-            <TagWrapper key={tag.stackType}>
-              <Keyword>{tag.stackType}</Keyword>
-            </TagWrapper>
-          ))}
-        </div>
-      </TagContainer>
+      {tags && <StyledHeader>사용 기술</StyledHeader>}
+      {tags && (
+        <TagContainer>
+          <div>
+            {tags.map((tag) => (
+              <TagWrapper key={tag.stackType}>
+                <Keyword>{tag.stackType}</Keyword>
+              </TagWrapper>
+            ))}
+          </div>
+        </TagContainer>
+      )}
       <StyledHeader>프로젝트 소개</StyledHeader>
+      <ProjectTitleBox>
+        <div>
+          <h4>프로젝트명</h4>
+        </div>
+        <Column />
+        <div>
+          <ProjectTitle>{projectName}</ProjectTitle>
+        </div>
+      </ProjectTitleBox>
+      <h4>상세 내용</h4>
       <Description>
         <p>{content}</p>
       </Description>

--- a/components/pages/detailPage/ContentDetail/index.tsx
+++ b/components/pages/detailPage/ContentDetail/index.tsx
@@ -9,17 +9,20 @@ import {
   ProjectTitleBox,
 } from "@/detailComps/ContentDetail/styled";
 import { TagWrapper } from "@/postComps/TagBox/styled";
+import Link from "next/link";
 
 interface ContentDetailProps {
   projectName: string;
   content: string;
   tags?: TagType[];
+  projectUrl: string;
 }
 
 export default function ContentDetail({
   projectName,
   content,
   tags,
+  projectUrl,
 }: ContentDetailProps) {
   return (
     <Wrapper>
@@ -42,7 +45,13 @@ export default function ContentDetail({
         </div>
         <Column />
         <div>
-          <ProjectTitle>{projectName}</ProjectTitle>
+          {projectUrl ? (
+            <Link href={projectUrl} target="_blank">
+              <ProjectTitle>{projectName}</ProjectTitle>
+            </Link>
+          ) : (
+            <ProjectTitle>{projectName}</ProjectTitle>
+          )}
         </div>
       </ProjectTitleBox>
       <h4>상세 내용</h4>

--- a/components/pages/detailPage/ContentDetail/index.tsx
+++ b/components/pages/detailPage/ContentDetail/index.tsx
@@ -15,7 +15,7 @@ interface ContentDetailProps {
   projectName: string;
   content: string;
   tags?: TagType[];
-  projectUrl: string;
+  projectUrl?: string;
 }
 
 export default function ContentDetail({

--- a/components/pages/detailPage/ContentDetail/styled.ts
+++ b/components/pages/detailPage/ContentDetail/styled.ts
@@ -30,3 +30,14 @@ export const Description = styled.div`
     padding: 0.35rem;
   }
 `;
+
+export const ProjectTitle = styled.span`
+  font-weight: 600;
+  letter-spacing: 0.15rem;
+`;
+
+export const ProjectTitleBox = styled.div`
+  display: flex;
+  align-items: center;
+  line-height: normal;
+`;

--- a/components/pages/detailPage/PostData/index.tsx
+++ b/components/pages/detailPage/PostData/index.tsx
@@ -69,14 +69,14 @@ export default function PostData({
         </div>
         <Column />
         <div>
-          <span>조회수 </span>
+          <span>조회 수 </span>
           <SpanStyled>{views}</SpanStyled>
-          {modalOn && <OptionModal id={id} />}
         </div>
         <Column />
         <div>
-          <BiBookmarkHeart />
+          <span>좋아요 </span>
           <SpanStyled>{likeNum}</SpanStyled>
+          {modalOn && <OptionModal id={id} />}
         </div>
         <OptionBox onClick={() => setModalOn((prev) => !prev)}>
           <BiDotsHorizontalRounded size={25} />
@@ -89,10 +89,14 @@ export default function PostData({
 
 function OptionModal({ id }: OptionModalProps) {
   const router = useRouter();
+  const postCategory = router.pathname.split("/")[1];
 
   // 게시글 삭제
   const deletePost = async (id: number) => {
-    const url = `${process.env.NEXT_PUBLIC_API_URL}/recruit-board/${id}`;
+    let url = process.env.NEXT_PUBLIC_API_URL as string;
+    if (postCategory === "recruits") url += "/recruit-board/" + id;
+    if (postCategory === "projects") url += "/free-boards/" + id;
+
     try {
       const res = await axios.delete(url, {
         headers: {
@@ -111,12 +115,12 @@ function OptionModal({ id }: OptionModalProps) {
   const handleDelete = async () => {
     if (window.confirm("정말 삭제하시겠습니까?")) {
       await deletePost(id);
-      await router.push("/recruits");
+      await router.push(`/${postCategory}`);
     }
   };
 
   const handleEdit = async () => {
-    await router.push(`/recruits/edit/${id}`);
+    await router.push(`/${postCategory}/edit/${id}`);
   };
 
   return (

--- a/components/pages/detailPage/PostData/index.tsx
+++ b/components/pages/detailPage/PostData/index.tsx
@@ -7,6 +7,7 @@ import {
   BiDotsHorizontalRounded,
   BiEditAlt,
   BiTrash,
+  BiBookmarkHeart,
 } from "react-icons/bi";
 import {
   PostTitle,
@@ -26,6 +27,7 @@ interface PostDataProps {
   title: string;
   createdAt: string;
   views: number;
+  likeNum: number;
 }
 
 interface OptionModalProps {
@@ -37,6 +39,7 @@ export default function PostData({
   title,
   createdAt,
   views,
+  likeNum,
 }: PostDataProps) {
   const [modalOn, setModalOn] = useState(false);
 
@@ -69,6 +72,11 @@ export default function PostData({
           <span>조회수 </span>
           <SpanStyled>{views}</SpanStyled>
           {modalOn && <OptionModal id={id} />}
+        </div>
+        <Column />
+        <div>
+          <BiBookmarkHeart />
+          <SpanStyled>{likeNum}</SpanStyled>
         </div>
         <OptionBox onClick={() => setModalOn((prev) => !prev)}>
           <BiDotsHorizontalRounded size={25} />

--- a/components/pages/detailPage/PostData/index.tsx
+++ b/components/pages/detailPage/PostData/index.tsx
@@ -7,7 +7,6 @@ import {
   BiDotsHorizontalRounded,
   BiEditAlt,
   BiTrash,
-  BiBookmarkHeart,
 } from "react-icons/bi";
 import {
   PostTitle,

--- a/pages/post/project.tsx
+++ b/pages/post/project.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import axios from "axios";
 import { Wrapper, Contents } from "@/postComps/common/PageLayout.styled";
@@ -55,7 +55,8 @@ export default function PostProjectPage() {
         return newErrorMsgs;
       },
       onSubmit: async () => {
-        const data = { ...postForm, projectUrl, imgSrc: null };
+        // TODO 이미지 추가 필요
+        const data = { ...postForm, projectUrl };
 
         // request
         axios
@@ -66,7 +67,7 @@ export default function PostProjectPage() {
             },
           })
           .then((res) => {
-            console.log(res);
+            console.log("API 반환값", res);
             if (res.status === 200) {
               window.alert("게시글 등록이 완료되었습니다");
               router.push(`/projects/${res.data.id}`);
@@ -83,6 +84,10 @@ export default function PostProjectPage() {
     if (window.confirm("작성중인 내용이 사라집니다. 계속 진행하시겠습니까?"))
       router.push("/projects");
   };
+
+  useEffect(() => {
+    console.log(postForm);
+  }, [postForm]);
 
   return (
     <Wrapper>

--- a/pages/projects/[projectId].tsx
+++ b/pages/projects/[projectId].tsx
@@ -1,0 +1,61 @@
+import axios from "axios";
+import { GetServerSidePropsContext } from "next";
+import { Wrapper, Contents } from "@/postComps/common/PageLayout.styled";
+import ContentDetail from "@/detailComps/ContentDetail";
+import CommentBox from "@/detailComps/CommentBox";
+import PostData from "@/detailComps/PostData";
+
+interface ProjectDetailPageProps {
+  project: ProjectType;
+}
+
+export default function ProjectDetailPage({ project }: ProjectDetailPageProps) {
+  console.log(project);
+  const {
+    comments,
+    content,
+    createdAt,
+    id,
+    imgUrl,
+    likeNum,
+    projectName,
+    projectUrl,
+    title,
+    userId,
+    views,
+  } = project;
+
+  return (
+    <Wrapper>
+      <Contents>
+        <PostData
+          id={id}
+          title={title}
+          createdAt={createdAt}
+          views={views}
+          likeNum={likeNum}
+        />
+        <ContentDetail projectName={projectName} content={content} />
+        <CommentBox />
+      </Contents>
+    </Wrapper>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const projectId = ctx.params?.projectId;
+  const url = `${process.env.NEXT_PUBLIC_API_URL}/free-boards/${projectId}`;
+  try {
+    const res = await axios.get(url);
+    const project = await res.data;
+
+    return {
+      props: {
+        project,
+      },
+    };
+  } catch (err) {
+    console.log(err);
+    return { notFound: true };
+  }
+}

--- a/pages/projects/[projectId].tsx
+++ b/pages/projects/[projectId].tsx
@@ -35,7 +35,11 @@ export default function ProjectDetailPage({ project }: ProjectDetailPageProps) {
           views={views}
           likeNum={likeNum}
         />
-        <ContentDetail projectName={projectName} content={content} />
+        <ContentDetail
+          projectName={projectName}
+          content={content}
+          projectUrl={projectUrl}
+        />
         <CommentBox />
       </Contents>
     </Wrapper>

--- a/pages/projects/edit/[projectId].tsx
+++ b/pages/projects/edit/[projectId].tsx
@@ -1,0 +1,200 @@
+import { useState } from "react";
+import axios from "axios";
+import { GetServerSidePropsContext } from "next";
+import { Wrapper, Contents } from "@/postComps/common/PageLayout.styled";
+import { useRouter } from "next/router";
+import { useInputImage } from "@/hooks/useInputImage";
+import { DEFAULT_RECRUIT_CARD_IMAGE } from "../../../enum";
+import { useForm } from "@/hooks/useForm";
+import PageHead from "@/components/PageHead";
+import ProjectUrlBox from "@/postComps/ProjectUrlBox";
+import { PostTitleStyled } from "@/postComps/common/Title.styled";
+import {
+  ErrorMsg,
+  GuideWrapper,
+  ImageBox,
+  InputBox,
+  InputForm,
+  LabelForm,
+  SubmitBtnBox,
+  TextareaForm,
+} from "@/postComps/common/PostForm.styled";
+import Button from "@/components/Button";
+import Image from "next/image";
+import { POST_FORM } from "@/pages/post/recruit";
+
+interface EditProjectPageProps {
+  project: ProjectType;
+}
+
+export default function EditProjectPage({ project }: EditProjectPageProps) {
+  console.log(project);
+  const router = useRouter();
+  const [projectUrl, setProjectUrl] = useState("");
+  const { imgSrc, handleImgChange } = useInputImage(DEFAULT_RECRUIT_CARD_IMAGE);
+  const { postForm, errMsgs, touched, handleChange, handleBlur, handleSubmit } =
+    useForm({
+      initialVals: {
+        projectName: project.projectName,
+        title: project.title,
+        content: project.content,
+      },
+      validate: (postForm: typeof POST_FORM) => {
+        const newErrorMsgs = { ...POST_FORM };
+
+        // 프로젝트명
+        if (
+          postForm.projectName.trim().length < 3 ||
+          postForm.projectName.trim().length > 20
+        )
+          newErrorMsgs.projectName = "프로젝트명은 3~20자 이내로 입력해주세요";
+
+        // 게시글 제목
+        if (postForm.title.trim().length < 5)
+          newErrorMsgs.title = "게시글 제목은 5자 이상 입력해야 합니다";
+
+        // 상세 내용
+        if (postForm.content.trim().length < 20)
+          newErrorMsgs.content = "게시글 내용은 20자 이상 입력해야 합니다";
+
+        return newErrorMsgs;
+      },
+      onSubmit: async () => {
+        const patchData = {
+          ...project,
+          ...postForm,
+          imgSrc: null, // 이미지 사용 불가하여 null 대체
+          projectUrl,
+        };
+
+        // request
+        const url = `${process.env.NEXT_PUBLIC_API_URL}/free-boards/${project.id}`;
+        axios
+          .patch(url, patchData, {
+            headers: {
+              // 로그인 기능 미구현으로 NEXT_PUBLIC_TOKEN에 발급받은 토큰을 넣고 실행!
+              Authorization: `Bearer ${process.env.NEXT_PUBLIC_TOKEN}`,
+            },
+          })
+          .then((res) => {
+            console.log(res);
+            if (res.status === 200) {
+              window.alert("게시글 수정이 완료되었습니다");
+              router.push(`/projects/${project.id}`);
+            }
+          })
+          .catch((err) => {
+            console.log(err);
+            window.alert("게시글 수정에 실패했습니다");
+          });
+      },
+    });
+
+  // 등록 취소 버튼 클릭 핸들러
+  const handleCancel = () => {
+    if (window.confirm("작성중인 내용이 사라집니다. 계속 진행하시겠습니까?"))
+      router.push(`/projects/${project.id}`);
+  };
+
+  return (
+    <Wrapper>
+      <PageHead pageTitle="자랑 게시글 수정 | 사이드 이펙트" />
+      <Contents>
+        <PostTitleStyled>자랑 게시글 수정</PostTitleStyled>
+        <form onSubmit={handleSubmit}>
+          <InputBox>
+            <GuideWrapper>
+              <LabelForm htmlFor="projectName">프로젝트명</LabelForm>
+              <p>멋진 프로젝트 이름을 정해보세요</p>
+            </GuideWrapper>
+            <InputForm
+              type="text"
+              id="projectName"
+              name="projectName"
+              value={postForm.projectName}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              placeholder="3~20자 이내로 입력해주세요"
+            />
+            {touched.projectName && errMsgs.projectName && (
+              <ErrorMsg>{errMsgs.projectName}</ErrorMsg>
+            )}
+          </InputBox>
+          <InputBox>
+            <GuideWrapper>
+              <LabelForm htmlFor="title">게시글 제목</LabelForm>
+              <p>제목에 핵심 내용을 드러내보세요</p>
+            </GuideWrapper>
+            <InputForm
+              type="text"
+              id="title"
+              name="title"
+              value={postForm.title}
+              onChange={handleChange}
+              onBlur={handleBlur}
+            />
+            {touched.title && errMsgs.title && (
+              <ErrorMsg>{errMsgs.title}</ErrorMsg>
+            )}
+          </InputBox>
+          <ProjectUrlBox
+            projectUrl={projectUrl}
+            setProjectUrl={setProjectUrl}
+          />
+          <InputBox>
+            <LabelForm htmlFor="image">대표 이미지</LabelForm>
+            <InputForm
+              name="image"
+              type="file"
+              accept="image/*"
+              onChange={handleImgChange}
+            />
+            <ImageBox>
+              {imgSrc === DEFAULT_RECRUIT_CARD_IMAGE && (
+                <p>이미지 미설정 시 적용될 기본 이미지입니다</p>
+              )}
+              <Image src={imgSrc} alt="" width={250} height={150} priority />
+            </ImageBox>
+          </InputBox>
+          <InputBox>
+            <LabelForm htmlFor="content">상세 내용</LabelForm>
+            <TextareaForm
+              id="content"
+              name="content"
+              value={postForm.content}
+              onChange={handleChange}
+              onBlur={handleBlur}
+            />
+            {touched.content && errMsgs.content && (
+              <ErrorMsg>{errMsgs.content}</ErrorMsg>
+            )}
+          </InputBox>
+          <SubmitBtnBox>
+            <Button type="submit">수정</Button>
+            <Button type="button" onClick={handleCancel}>
+              취소
+            </Button>
+          </SubmitBtnBox>
+        </form>
+      </Contents>
+    </Wrapper>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const projectId = ctx.params?.projectId;
+  const url = `${process.env.NEXT_PUBLIC_API_URL}/free-boards/${projectId}`;
+  try {
+    const res = await axios.get(url);
+    const project = await res.data;
+
+    return {
+      props: {
+        project,
+      },
+    };
+  } catch (err) {
+    console.log(err);
+    return { notFound: true };
+  }
+}

--- a/pages/recruits/[recruitId].tsx
+++ b/pages/recruits/[recruitId].tsx
@@ -11,13 +11,31 @@ interface RecruitDetailPageProps {
 }
 
 export default function RecruitDetailPage({ recruit }: RecruitDetailPageProps) {
-  const { id, title, projectName, positions, createdAt, views, tags, content } =
-    recruit;
+  console.log(recruit);
+  const {
+    id,
+    title,
+    projectName,
+    positions,
+    createdAt,
+    views,
+    tags,
+    content,
+    userId,
+    likeNum,
+    imgSrc,
+  } = recruit;
 
   return (
     <Wrapper>
       <Contents>
-        <PostData id={id} title={title} createdAt={createdAt} views={views} />
+        <PostData
+          id={id}
+          title={title}
+          createdAt={createdAt}
+          views={views}
+          likeNum={likeNum}
+        />
         <PositionDetail positions={positions} />
         <ContentDetail
           projectName={projectName}

--- a/pages/recruits/[recruitId].tsx
+++ b/pages/recruits/[recruitId].tsx
@@ -51,6 +51,7 @@ export default function RecruitDetailPage({ recruit }: RecruitDetailPageProps) {
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const recruitId = ctx.params?.recruitId;
   const url = `${process.env.NEXT_PUBLIC_API_URL}/recruit-board/${recruitId}`;
+
   try {
     const res = await axios.get(url);
     const recruit = await res.data;

--- a/types/projects.ts
+++ b/types/projects.ts
@@ -20,5 +20,5 @@ declare interface ProjectType {
   likeNum: number;
   comments?: CommentType[];
   commentNum?: number;
-  createdAt?: string;
+  createdAt: string;
 }

--- a/types/recruit.ts
+++ b/types/recruit.ts
@@ -20,4 +20,6 @@ declare interface RecruitType {
   tags: TagType[];
   title: string;
   views: number;
+  likeNum: number;
+  userId: number;
 }

--- a/utils/converter.ts
+++ b/utils/converter.ts
@@ -1,11 +1,9 @@
-import { getTodayDate } from "./getTodayDate";
-
 // 모집 게시판 API의 반환 데이터를 BoardCard data props로 변환하는 함수
 export const recruitBoardCardConverter = (
   category: string,
   fetchedData: RecruitType,
 ) => {
-  const { id, content, tags, title, projectName, imgSrc, positions } =
+  const { id, content, tags, title, projectName, imgSrc, likeNum, createdAt } =
     fetchedData;
   const newTags = tags.map((tag) => tag.stackType);
   return {
@@ -16,9 +14,8 @@ export const recruitBoardCardConverter = (
     tags: newTags,
     title,
     content,
-    createdAt: getTodayDate(),
-    like: !!Math.round(Math.random()),
-    likeNum: Math.round(Math.random() * 100),
-    commentNum: Math.round(Math.random() * 100),
+    createdAt,
+    like: !!Math.round(Math.random()), // 화면 확인을 위해 임시로 랜덤하게
+    likeNum,
   };
 };


### PR DESCRIPTION
1. 프로젝트 자랑 게시글의 수정, 삭제, 상세페이지 조회 기능을 구현했습니다
- 댓글 기능은 추후 추가 예정입니다


2. 모바일 헤더 메뉴 클릭시 메뉴가 닫히지 않는 현상 수정했습니다

3. 모집 게시판에서 board card에 전달되는 값을 실제 값으로 변경했습니다(createdAt, likeNum)
- 다만, 좋아요 여부를 담당하는 like 는 아직 좋아요 기능을 구현하지 않아 랜덤하게 두었습니다